### PR TITLE
Small bug in version specifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
 		],
 	
 	requires=['mpyq'],
-    install_requires=['mpyq=0.1.5'],
+	install_requires=['mpyq==0.1.5'],
 	packages=['sc2reader'],
 	scripts=['scripts/sc2printer'],
 )


### PR DESCRIPTION
setuptools version numbers for dependencies are boolean comparisons, thus double equals is required
