### PR TITLE
[scripts] add replay to json script

### DIFF
--- a/sc2reader/scripts/sc2json.py
+++ b/sc2reader/scripts/sc2json.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+import sc2reader
+from sc2reader.plugins.replay import toJSON
+
+def main():
+    factory = sc2reader.factories.SC2Factory()
+    factory.register_plugin("Replay", toJSON())
+
+    replay_json = factory.load_replay(sys.argv[1])
+    print replay_json
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
A helper script to dump json stats about a replay passed by filename in argv.

```
mjolnir:sc2reader clundquist$ sc2reader/scripts/sc2json.py "/Users/clundquist/Library/Application Support/Blizzard/StarCraft II/Accounts/1454200/1-S2-1-501405/Replays/Multiplayer/Derelict Watcher TE (208 Balance v11).SC2Replay"
{"is_ladder": false, "file_time": null, "real_type": "1v1", "frames": 223, "speed": "Faster", "gateway": "us", "category": "Public", "filehash": "dd845c1c3f1f8bc9b49d12ee692e9b7f19bc45478e1c672e6b03c40478505f91", "filename": "/Users/clundquist/Library/Application Support/Blizzard/StarCraft II/Accounts/1454200/1-S2-1-501405/Replays/Multiplayer/Derelict Watcher TE (208 Balance v11).SC2Replay", "build": 26147, "game_length": 13, "unix_timestamp": 1373691657, "type": "1v1", "real_length": 9, "observers": [], "map_name": "Derelict Watcher TE (2.0.8 Balance v1.1)", "game_fps": 16.0, "date": "2013-07-13 05:00:57", "utc_date": null, "is_private": false, "versions": [1, 2, 0, 9, 26147, 24944], "time_zone": -7, "players": [{"uid": 1032805, "play_race": "Protoss", "handicap": 100, "pick_race": "Protoss", "pid": 1, "result": "Win", "name": "Bmn", "url": "http://us.battle.net/sc2/en/profile/1032805/1/Bmn/", "messages": [], "color": {"a": 255, "r": 0, "b": 255, "name": "Blue", "g": 66}, "type": null, "avg_apm": null}, {"uid": 501405, "play_race": "Protoss", "handicap": 100, "pick_race": "Random", "pid": 2, "result": "Loss", "name": "Durandal", "url": "http://us.battle.net/sc2/en/profile/501405/1/Durandal/", "messages": [], "color": {"a": 255, "r": 180, "b": 30, "name": "Red", "g": 20}, "type": null, "avg_apm": null}], "release": "2.0.9.26147"}
```

I need the "real_length" attribute so I know how long to screen record
