### PR TITLE
Fix: add missing player_names to Replay object

### DIFF
--- a/sc2reader/resources.py
+++ b/sc2reader/resources.py
@@ -419,6 +419,7 @@ class Replay(Resource):
                 entity.team.players.append(entity)
                 self.players.append(entity)
                 self.player[entity.pid] = entity
+                self.player_names.append(entity.name)
             else:
                 self.observers.append(entity)
                 self.observer[entity.uid] = entity


### PR DESCRIPTION
Fix an issue with player_names not being updated in ressources.Replay object.
