### PR TITLE
decoding upgrade_type_name so that it reads as a string not bytes in python 3

### DIFF
--- a/sc2reader/events/tracker.py
+++ b/sc2reader/events/tracker.py
@@ -442,7 +442,7 @@ class UpgradeCompleteEvent(TrackerEvent):
         self.player = None
 
         #: The name of the upgrade
-        self.upgrade_type_name = data[1]
+        self.upgrade_type_name = data[1].decode('utf8')
 
         #: The number of times this upgrade as been researched
         self.count = data[2]


### PR DESCRIPTION
It looks like the rest of these event types do this conversion, and it was just an oversight. I ran into an issue with this in spawningtool where I had to convert things on my side to get it to work.